### PR TITLE
update action to use a pre-compiled binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,3 +19,25 @@ jobs:
     uses: StanfordBDHG/.github/.github/workflows/action-release-tag.yml@v2
     permissions:
       contents: write
+  build-and-upload:
+    name: Build and Upload Binaries
+    # This tool deals with xcresult, so it must run on macOS
+    runs-on: macos-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Setup Swift
+        uses: swift-actions/setup-swift@v2
+        with:
+          swift-version: "6"
+      - name: Build binary
+        run: swift build -c release --product xccov2lcov
+      - name: Create archive
+        run: |
+          cd .build/release
+          tar -czf xccov2lcov-macos.tar.gz xccov2lcov
+      - name: Upload release asset
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload ${{ github.ref_name }} .build/release/xccov2lcov-macos.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,6 @@ jobs:
       contents: write
   build-and-upload:
     name: Build and Upload Binaries
-    # This tool deals with xcresult, so it must run on macOS
     runs-on: macos-latest
     steps:
       - name: Checkout code
@@ -36,7 +35,7 @@ jobs:
         run: |
           cd .build/release
           tar -czf xccov2lcov-macos.tar.gz xccov2lcov
-      - name: Upload release asset
+      - name: Upload binary
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/action.yml
+++ b/action.yml
@@ -16,14 +16,23 @@ inputs:
   xcresult:
     description: 'xcresult bundle'
     required: true
-    type: string
 runs:
   using: "composite"
   steps:
-    - name: Build xccov
+    - name: Download xccov2lcov binary
       shell: bash
-      run: swift build -c release --product xccov2lcov
-      working-directory: ${{ github.action_path }}
-    - name: xccov
+      run: |
+        set -e
+        VERSION="${{ github.action_ref }}"
+        URL="https://github.com/${{ github.action_repository }}/releases/download/${VERSION}/xccov2lcov-macos.tar.gz"
+        echo "Downloading xccov2lcov from ${URL}..."
+        curl -sL "${URL}" -o xccov2lcov.tar.gz
+        # Extract and make executable
+        tar -xzf xccov2lcov.tar.gz
+        chmod +x xccov2lcov
+        # Add the binary's location to the PATH for subsequent steps
+        echo "${{ github.action_path }}" >> $GITHUB_PATH
+    - name: Convert to lcov
       shell: bash
-      run: xcrun xccov view --report --json ${{ inputs.xcresult }} | ${{ github.action_path }}/.build/release/xccov2lcov > info.lcov
+      run: |
+        xcrun xccov view --report --json ${{ inputs.xcresult }} | xccov2lcov > info.lcov

--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ runs:
   env:
     ACTION_VERSION: ${{ inputs.version }}
   steps:
-    - name: Download xccov2lcov binary
+    - name: Download xccov2lcov
       shell: bash
       run: |
         set -e
@@ -43,7 +43,7 @@ runs:
         chmod +x xccov2lcov
         # Add the binary's location to the PATH for subsequent steps
         echo "${{ github.action_path }}" >> $GITHUB_PATH
-    - name: Convert to lcov
+    - name: Run xccov2lcov
       shell: bash
       run: |
         xcrun xccov view --report --json ${{ inputs.xcresult }} | xccov2lcov > info.lcov

--- a/action.yml
+++ b/action.yml
@@ -16,14 +16,25 @@ inputs:
   xcresult:
     description: 'xcresult bundle'
     required: true
+  version:
+    description: 'The version of the xccov2lcov binary to download. Defaults to the version of the action.'
+    required: false
+    default: ${{ github.action_ref }}
 runs:
   using: "composite"
+  env:
+    ACTION_VERSION: ${{ inputs.version }}
   steps:
     - name: Download xccov2lcov binary
       shell: bash
       run: |
         set -e
-        VERSION="${{ github.action_ref }}"
+        VERSION="$XCCOV_VERSION"
+        # Check if version is empty or a branch ref, and handle it
+        if [[ -z "$VERSION" ]] || [[ "$VERSION" == refs/heads/* ]]; then
+          echo "Error: Could not determine a release version. Please specify a version tag (e.g., @v1.2.3) or provide a 'version' input."
+          exit 1
+        fi
         URL="https://github.com/${{ github.action_repository }}/releases/download/${VERSION}/xccov2lcov-macos.tar.gz"
         echo "Downloading xccov2lcov from ${URL}..."
         curl -sL "${URL}" -o xccov2lcov.tar.gz


### PR DESCRIPTION
# update action to use a pre-compiled binary

## :recycle: Current situation & Problem
the GitHub action provided by this repo currently re-compiles the xccov2lcov tool every time the action is invoked. this is not good practice.

solution:
- we instead add a new step to our release job, to create a compiled binary and attach that to the release.
- we also update the action.yml to download and use this binary, rather than compiling the tool.

@PSchmiedmayer i'm not sure if the implementation here is correct, but i'm also not sure how we could test it without just merging it and seeing if it works?


## :gear: Release Notes
- switch action to use pre-compiled binaries rather than compiling the tool on every run


## :books: Documentation
n/a; users should be able to continue to use the action as-is, without having to change anything in their workflows.


## :white_check_mark: Testing
n/a


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
