### PR TITLE
add `output` option

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -213,7 +213,7 @@ only_rules:
   # Operators should be surrounded by a single whitespace when they are being used.
   - operator_usage_whitespace
   # Operators should be surrounded by a single whitespace when defining them.
-  - operator_whitespace
+  - function_name_whitespace
   # Matching an enum case against an optional enum without ‘?’ is supported on Swift 5.1 and above.
   - optional_enum_case_matching
   # A doc comment should be attached to a declaration.
@@ -255,7 +255,7 @@ only_rules:
   # Objective-C attribute (@objc) is redundant in declaration.
   - redundant_objc_attribute
   # Initializing an optional variable with nil is redundant.
-  - redundant_optional_initialization
+  - implicit_optional_initialization
   # Property setter access level shouldn't be explicit if it's the same as the variable access level.
   - redundant_set_access_control
   # String enum values can be omitted when they are equal to the enumcase name.

--- a/Tests/XCCovLibTests/XCCovLibTests.swift
+++ b/Tests/XCCovLibTests/XCCovLibTests.swift
@@ -97,7 +97,7 @@ struct XCCovLibTests {
     
     
     @Test
-    func testTargetFullMode () {
+    func testTargetFullMode() {
         let fn1 = XCCovFunction(coveredLines: 1, executableLines: 2, lineCoverage: 3.0, executionCount: 4, lineNumber: 5, name: "fn1")
         let fn2 = XCCovFunction(coveredLines: 6, executableLines: 7, lineCoverage: 8.5, executionCount: 9, lineNumber: 10, name: "fn2")
         let file = XCCovFile(coveredLines: 1, executableLines: 2, lineCoverage: 3.5, name: "filename", path: "filepath", functions: [fn1, fn2])

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,10 @@ inputs:
   xcresult:
     description: 'xcresult bundle'
     required: true
+  output:
+    description: 'output file'
+    required: false
+    default: 'info.lcov'
 runs:
   using: "composite"
   steps:
@@ -36,4 +40,4 @@ runs:
     - name: Run xccov2lcov
       shell: bash
       run: |
-        xcrun xccov view --report --json ${{ inputs.xcresult }} | $XCCOV2lCOV_BINARY > info.lcov
+        xcrun xccov view --report --json ${{ inputs.xcresult }} | $XCCOV2lCOV_BINARY > ${{ inputs.output }}


### PR DESCRIPTION
# add `output` option

## :recycle: Current situation & Problem
the output file currently is always called `info.lcov`; this PR allows customising it. the default value remains `info.lcov`


## :gear: Release Notes
- new `output` option; defaults to info.lcov


## :books: Documentation
yes


## :white_check_mark: Testing
n/a


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
